### PR TITLE
Chore Backend Dependencia h2

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -59,6 +59,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,3 +1,22 @@
 spring:
   application:
     name: churninsight
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop  # Recrea tablas cada vez que inicias
+    show-sql: true  # Muestra las queries SQL en consola
+    properties:
+      hibernate:
+        format_sql: true


### PR DESCRIPTION
Se agrega la dependencia h2 para poder ejecutar la api de spring boot y hacer pruebas momentaneas creando una base de datos en memoria sin necesidad de MySQL