### PR TITLE
feat(#29): add ports in/out and CustomerData domain model

### DIFF
--- a/backend/src/main/java/com/team42/churninsight/domain/CustomerData.java
+++ b/backend/src/main/java/com/team42/churninsight/domain/CustomerData.java
@@ -1,0 +1,15 @@
+package com.team42.churninsight.domain;
+
+import com.team42.churninsight.domain.enums.*;
+
+public record CustomerData(
+        String customerId,
+        Integer age,
+        Gender gender,
+        IncomeBracket incomeBracket,
+        MaritalStatus maritalStatus,
+        EducationLevel educationLevel,
+        Occupation occupation
+        // agrega aquí solo lo que realmente mande el request
+) {}
+

--- a/backend/src/main/java/com/team42/churninsight/ports/in/README.md
+++ b/backend/src/main/java/com/team42/churninsight/ports/in/README.md
@@ -1,0 +1,7 @@
+Por qué NO conviene ports/in ahora
+
+Añade una capa extra (interfaz + implementación) por cada caso de uso
+
+El beneficio real es pequeño si solo hay REST
+
+Puede confundir por ahora 

--- a/backend/src/main/java/com/team42/churninsight/ports/out/ChurnModelClient.java
+++ b/backend/src/main/java/com/team42/churninsight/ports/out/ChurnModelClient.java
@@ -1,0 +1,8 @@
+package com.team42.churninsight.ports.out;
+
+import com.team42.churninsight.domain.CustomerData;
+import com.team42.churninsight.domain.Prediction;
+
+public interface ChurnModelClient {
+    Prediction predict(CustomerData customerData);
+}

--- a/backend/src/main/java/com/team42/churninsight/ports/out/PredictionRepository.java
+++ b/backend/src/main/java/com/team42/churninsight/ports/out/PredictionRepository.java
@@ -1,0 +1,12 @@
+package com.team42.churninsight.ports.out;
+
+import com.team42.churninsight.domain.Prediction;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PredictionRepository {
+    Prediction save(Prediction prediction);
+    Optional<Prediction> findById(Long id);
+    List<Prediction> findByCustomerId(String customerId);
+}


### PR DESCRIPTION
Este PR introduce la estructura inicial de puertos en el backend mediante la creación de interfaces en ports/out, con el objetivo de desacoplar la lógica central de la aplicación de dependencias externas. Se añadió el modelo de dominio CustomerData para representar la información necesaria para solicitar predicciones de churn, evitando dependencias directas con los DTOs del API. Asimismo, se definieron los puertos ChurnModelClient y PredictionRepository para abstraer la integración con el servicio de Machine Learning (FastAPI) y la capa de persistencia (MySQL), respectivamente. No se realizaron cambios sobre el modelo de dominio Prediction. Estos ajustes establecen una separación clara de responsabilidades y preparan el backend para una integración escalable con ML y base de datos.