### PR TITLE
docs/backend dependencia de swagger-openapi

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -68,6 +68,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
se agrega la dependencia de openapi para generar la documentacion de los endpoints