### PR TITLE
feat: se agrega persistencia para prediccion usando JPA y H2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,8 @@ auth.json
 *.project
 *.settings/
 bin/
+
+# H2 database files
+/data/
+/*.mv.db
+/*.trace.db

--- a/backend/src/main/java/com/team42/churninsight/prediction/repository/PredictionRepository.java
+++ b/backend/src/main/java/com/team42/churninsight/prediction/repository/PredictionRepository.java
@@ -1,0 +1,7 @@
+package com.team42.churninsight.prediction.repository;
+
+import com.team42.churninsight.prediction.Prediction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PredictionRepository extends JpaRepository<Prediction, Long> {
+}

--- a/backend/src/main/java/com/team42/churninsight/prediction/service/PredictionServiceImpl.java
+++ b/backend/src/main/java/com/team42/churninsight/prediction/service/PredictionServiceImpl.java
@@ -7,9 +7,11 @@
  *   (más allá de Bean Validation en el DTO).
  * - Delegar la inferencia al modelo externo (FastAPI) mediante ChurnModelClient.
  * - Normalizar la salida del modelo al contrato de la API (probability_churn en [0..1]).
+ *   ESTA PARTE DEBERA BORRARSE AHORA LO DECIDIRÁ LA ENTIDAD
  * - Derivar el label (churn = true/false) usando un umbral (threshold) configurable.
  *
- * Alcance actual:
+ *   Alcance actual: (ESTA PARTE DEBERA BORRARSE FINALIZADA LA PERSISTENCIA)
+ *    --- Hay persistencia vía JPA (H2 en dev) ---
  * - No hay persistencia (H2 pendiente). Se devuelve una respuesta construida en memoria.
  *
  * Notas de diseño:
@@ -18,12 +20,34 @@
  * - Este Service no conoce HTTP (ResponseEntity, status codes), solo dominio.
  */
 
+/**  2026-01-07
+ * CAMBIOS RECIENTES (Persistencia JPA / H2)
+ *
+ * - El Service actúa como orquestador del caso de uso: valida, invoca el modelo,
+ *   construye la entidad Prediction, persiste el resultado y devuelve la respuesta.
+ *
+ * - La decisión del estado de churn se delega exclusivamente a la entidad Prediction
+ *   (single source of truth), evitando duplicar lógica en el Service.
+ *
+ * - El resultado de la predicción se persiste antes de responder al cliente,
+ *   garantizando coherencia entre lo almacenado y lo expuesto por la API.
+ *
+ * - Prediction representa el modelo de dominio/persistencia, mientras que
+ *   PredictionResponse es un DTO propio de la capa API.
+ */
+
 package com.team42.churninsight.prediction.service;
 
 import com.team42.churninsight.common.exception.InvalidPredictionRequestException;
+import com.team42.churninsight.prediction.Prediction;
 import com.team42.churninsight.prediction.api.dto.PredictionRequest;
 import com.team42.churninsight.prediction.api.dto.PredictionResponse;
 import com.team42.churninsight.prediction.client.ChurnModelClient;
+
+import com.team42.churninsight.prediction.enums.Churn;
+import com.team42.churninsight.prediction.repository.PredictionRepository;
+
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -34,9 +58,8 @@ import java.math.RoundingMode;
 @RequiredArgsConstructor
 public class PredictionServiceImpl implements PredictionService {
 
-    private static final BigDecimal DEFAULT_THRESHOLD = new BigDecimal("0.50");
-
     private final ChurnModelClient churnModelClient;
+    private final PredictionRepository predictionRepository;
 
 
     /**
@@ -44,8 +67,9 @@ public class PredictionServiceImpl implements PredictionService {
      * Flujo:
      * 1) Valida reglas de negocio (coherencias entre campos).
      * 2) Llama al modelo vía ChurnModelClient.
-     * 3) Convierte la salida del modelo a probabilidad [0..1].
-     * 4) Decide churn con threshold.
+     * 3) Convierte la salida del modelo a probabilidad [0..1]. (actualizado:tu client
+     *    ya devuelve BigDecimal en [0..1] por ahora)
+     * 4) Decide churn con threshold. (ya no; lo decide la entidad)
      * 5) Construye PredictionResponse.
      */
 
@@ -56,17 +80,31 @@ public class PredictionServiceImpl implements PredictionService {
         // 1) Llamada al modelo
         BigDecimal probability = churnModelClient.predictChurn(request);
 
+        Prediction entity = Prediction.create(
+                request.customerId(),
+                request.transactionId(),
+                probability.doubleValue()
+        );
+
+        Prediction saved = predictionRepository.save(entity);
+        //predictionRepository.save(entity);
+
+        boolean churn = saved.getChurn() == Churn.CHURN;
+        //boolean churn = entity.getChurn() == Churn.CHURN;
+
         // 2) Normalización a probabilidad [0..1]
         //BigDecimal probability = normalizeProbability(raw);
 
+/*      Ya no es necesario si entidad Prediction es la fuente de verdad y vamos a persistir entity
         // 3) Decisión (umbral por ahora fijo)
         boolean churn = probability.compareTo(DEFAULT_THRESHOLD) >= 0;
-
-        // 4) Respuesta (sin persistencia por ahora)
+*/
+        // 4) Respuesta (necesario para persistencia)
         return new PredictionResponse(
-                request.customerId(),
+                saved.getCustomerId(),    // en vez de request.customerId()
+                //entity.getCustomerId(),
                 churn,
-                probability
+                probability               // o BigDecimal.valueOf(entity.getProbabilityChurn())
         );
     }
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -3,7 +3,7 @@ spring:
     name: churninsight
 
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:file:./data/churninsight;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -15,7 +15,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop  # Recrea tablas cada vez que inicias
+      ddl-auto: update  # Mantiene el esquema y aplica cambios sin borrar datos
     show-sql: true  # Muestra las queries SQL en consola
     properties:
       hibernate:


### PR DESCRIPTION
Descripción del Pull Request

Este PR incorpora persistencia de predicciones de churn utilizando Spring Data JPA con H2.

Ahora, cada predicción se guarda en la base de datos antes de devolver la respuesta de la API, manteniendo el contrato actual sin cambios.

Cambios técnicos

Se agregó PredictionRepository usando Spring Data JPA.

Se actualizó PredictionServiceImpl para persistir el resultado de la predicción.

El cálculo del estado de churn se delega a la entidad Prediction como única fuente de verdad.

Se configuró H2 como base de datos local basada en archivo.

Se ignoraron los archivos locales de la base de datos (data/) en .gitignore.

Comportamiento

No se modifican endpoints existentes ni DTOs.

La respuesta de la API permanece igual.

Las predicciones se persisten de forma transparente en el backend.

Notas

H2 se utiliza únicamente para desarrollo local.

La migración a MySQL u Oracle (OCI) podrá realizarse sin cambios en la lógica del servicio.

Closes #59  