### PR TITLE
feat: add GET /api/customers/critical endpoint (issue #128)

### DIFF
--- a/backend/src/main/java/com/team42/churninsight/customer/api/CustomerController.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/api/CustomerController.java
@@ -1,0 +1,24 @@
+package com.team42.churninsight.customer.api;
+
+import com.team42.churninsight.customer.dto.CriticalCustomerResponse;
+import com.team42.churninsight.customer.service.CustomerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+
+
+@RestController
+@RequestMapping("/api/customers")
+@RequiredArgsConstructor
+public class CustomerController {
+
+    private final CustomerService customerService;
+
+    @GetMapping("/critical")
+    public List<CriticalCustomerResponse> getCriticalCustomers() {
+        return customerService.getCriticalCustomers();
+    }
+}

--- a/backend/src/main/java/com/team42/churninsight/customer/dto/CriticalCustomerResponse.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/dto/CriticalCustomerResponse.java
@@ -1,0 +1,12 @@
+package com.team42.churninsight.customer.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.team42.churninsight.economic.ValueCustomer;
+
+public record CriticalCustomerResponse(
+        @JsonProperty("customer_id") String customerId,
+        @JsonProperty("churn_probability") Double churnProbability,
+        @JsonProperty("economic_value") ValueCustomer economicValue,
+        @JsonProperty("priority_score") Double priorityScore,
+        @JsonProperty("recommended_action") String recommendedAction
+) {}

--- a/backend/src/main/java/com/team42/churninsight/customer/entity/CustomerCritical.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/entity/CustomerCritical.java
@@ -1,0 +1,73 @@
+package com.team42.churninsight.customer.entity;
+
+import com.team42.churninsight.economic.ValueCustomer;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+        name = "customer_critical",
+        uniqueConstraints = @UniqueConstraint(name = "uk_customer_critical_customer_id", columnNames = "customer_id")
+)
+public class CustomerCritical {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "customer_id", nullable = false)
+    private String customerId;
+
+    @Column(name = "priority_score", nullable = false)
+    private Double priorityScore;
+
+    @Column(name = "churn_probability", nullable = false)
+    private Double churnProbability;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "economic_value", nullable = false)
+    private ValueCustomer economicValue;
+
+    @Column(name = "recommended_action", nullable = false)
+    private String recommendedAction;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static CustomerCritical from(
+            String customerId,
+            Double priorityScore,
+            Double churnProbability,
+            ValueCustomer economicValue,
+            String recommendedAction
+    ) {
+        CustomerCritical cc = new CustomerCritical();
+        cc.setCustomerId(customerId);
+        cc.setPriorityScore(priorityScore);
+        cc.setChurnProbability(churnProbability);
+        cc.setEconomicValue(economicValue);
+        cc.setRecommendedAction(recommendedAction);
+        cc.setUpdatedAt(LocalDateTime.now());
+        return cc;
+    }
+
+    public void update(
+            Double priorityScore,
+            Double churnProbability,
+            ValueCustomer economicValue,
+            String recommendedAction
+    ) {
+        this.priorityScore = priorityScore;
+        this.churnProbability = churnProbability;
+        this.economicValue = economicValue;
+        this.recommendedAction = recommendedAction;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/team42/churninsight/customer/repository/CustomerCriticalRepository.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/repository/CustomerCriticalRepository.java
@@ -1,0 +1,14 @@
+package com.team42.churninsight.customer.repository;
+
+import com.team42.churninsight.customer.entity.CustomerCritical;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CustomerCriticalRepository extends JpaRepository<CustomerCritical, Long> {
+
+    Optional<CustomerCritical> findByCustomerId(String customerId);
+
+    List<CustomerCritical> findAllByOrderByPriorityScoreDesc();
+}

--- a/backend/src/main/java/com/team42/churninsight/customer/service/CustomerService.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/service/CustomerService.java
@@ -1,0 +1,9 @@
+package com.team42.churninsight.customer.service;
+
+import com.team42.churninsight.customer.dto.CriticalCustomerResponse;
+
+import java.util.List;
+
+public interface CustomerService {
+    List<CriticalCustomerResponse> getCriticalCustomers();
+}

--- a/backend/src/main/java/com/team42/churninsight/customer/service/CustomerServiceImpl.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/service/CustomerServiceImpl.java
@@ -1,0 +1,34 @@
+package com.team42.churninsight.customer.service;
+
+import com.team42.churninsight.customer.dto.CriticalCustomerResponse;
+import com.team42.churninsight.customer.entity.CustomerCritical;
+import com.team42.churninsight.customer.repository.CustomerCriticalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerServiceImpl implements CustomerService {
+
+    private final CustomerCriticalRepository repository;
+
+    @Override
+    public List<CriticalCustomerResponse> getCriticalCustomers() {
+        return repository.findAllByOrderByPriorityScoreDesc()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private CriticalCustomerResponse toResponse(CustomerCritical cc) {
+        return new CriticalCustomerResponse(
+                cc.getCustomerId(),
+                cc.getChurnProbability(),
+                cc.getEconomicValue(),
+                cc.getPriorityScore(),
+                cc.getRecommendedAction()
+        );
+    }
+}


### PR DESCRIPTION
Descripción

Se implementa el endpoint GET /api/customers/critical, que devuelve el listado de clientes críticos ordenado por priority_score (DESC) a partir de la información almacenada en la base de datos.

Detalles

Se agrega el módulo customer (entity, repository, service y controller).

Se define el DTO CriticalCustomerResponse como contrato de salida.

El alcance del PR se limita al issue #128.

No se modifica PredictionServiceImpl aun.  


Nota sobre funcionalidad

Para que el endpoint /api/customers/critical devuelva datos reales, será necesario en un PR posterior actualizar PredictionServiceImpl para persistir/actualizar el snapshot customer_critical en cada predicción.

Recomendado (consistencia, pero no bloquea)
2) Ajustar persistencia de recommended_action en predictions:
             setear entity.setRecommendedAction(recommendation) antes de guardar Prediction.