### PR TITLE
fix(back): validar existencia de customer antes de guardar

### DIFF
--- a/backend/src/main/java/com/team42/churninsight/prediction/service/PredictionServiceImpl.java
+++ b/backend/src/main/java/com/team42/churninsight/prediction/service/PredictionServiceImpl.java
@@ -59,6 +59,7 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -115,8 +116,15 @@ public class PredictionServiceImpl implements PredictionService {
         // 5) Identificar accion recomendada
         String recomendation = recommendedActionService.getRecommendation(probability.doubleValue(), valueCustomer,flags,profileType);
 
-        //crea el customer y lo persiste para crear el id (antes debería chequear si ya existe buscando por externalId)
-        Customer customerEntity = Customer.create(request.customerId(),priorityScore,valueCustomer, economicValueScore,profileType);
+        //crea el customer y valida si existe. Dependiendo del caso lo crea o lo actualiza.
+        Optional<Customer> customerOptional = customerRepository.findByExternalId(request.customerId());
+        Customer customerEntity;
+        if (customerOptional.isEmpty()){
+            customerEntity = Customer.create(request.customerId(),priorityScore,valueCustomer, economicValueScore,profileType);
+        }else {
+            customerEntity = customerOptional.get();
+            customerEntity.update(priorityScore,valueCustomer,economicValueScore,profileType);
+        }
         customerRepository.save(customerEntity);
 
         //crea la prediccion


### PR DESCRIPTION
Se agrega una validación en `PredictionServiceImpl` para comprobar si el customer ya existe (por `external_id`) antes de persistirlo.

### Cambios realizados
- Se consulta el customer por `external_id`.
- Si existe, se actualizan sus datos.
- Si no existe, se crea un nuevo registro.
- Se evita la creación de customers duplicados.

### Resultado
- Corrección del flujo de persistencia de customers.
- Datos de clientes consistentes en base de datos.
- Comportamiento alineado con MySQL y JPA.