### PR TITLE
feat(back): agregar recommended_action a respuesta de clientes criticos

### DIFF
--- a/backend/src/main/java/com/team42/churninsight/customer/dto/CriticalCustomerResponse.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/dto/CriticalCustomerResponse.java
@@ -8,5 +8,6 @@ import java.math.BigDecimal;
 public record CriticalCustomerResponse(
         @JsonProperty("customer_id") String customerId,
         @JsonProperty("economic_value") ValueCustomer economicValue,
-        @JsonProperty("priority_score") BigDecimal priorityScore
+        @JsonProperty("priority_score") BigDecimal priorityScore,
+        @JsonProperty("recommended_action") String recommendedAction
 ) {}

--- a/backend/src/main/java/com/team42/churninsight/customer/repository/CustomerRepository.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/repository/CustomerRepository.java
@@ -10,5 +10,5 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
     Optional<Customer> findByExternalId(String externalId);
 
-    List<Customer> findAllByOrderByPriorityScoreDesc();
+    List<Customer> findTop5ByOrderByPriorityScoreDesc();
 }

--- a/backend/src/main/java/com/team42/churninsight/customer/service/CustomerServiceImpl.java
+++ b/backend/src/main/java/com/team42/churninsight/customer/service/CustomerServiceImpl.java
@@ -3,6 +3,7 @@ package com.team42.churninsight.customer.service;
 import com.team42.churninsight.customer.dto.CriticalCustomerResponse;
 import com.team42.churninsight.customer.entity.Customer;
 import com.team42.churninsight.customer.repository.CustomerRepository;
+import com.team42.churninsight.prediction.repository.PredictionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,20 +14,23 @@ import java.util.List;
 public class CustomerServiceImpl implements CustomerService {
 
     private final CustomerRepository repository;
+    private final PredictionRepository predictionRepository;
 
     @Override
     public List<CriticalCustomerResponse> getCriticalCustomers() {
-        return repository.findAllByOrderByPriorityScoreDesc()
+        return repository.findTop5ByOrderByPriorityScoreDesc()
                 .stream()
                 .map(this::toResponse)
                 .toList();
     }
 
     private CriticalCustomerResponse toResponse(Customer cc) {
+        String recommendedAction = predictionRepository.findLastRecommendedActionByCustomer(cc.getId()).orElse(null);
         return new CriticalCustomerResponse(
                 cc.getExternalId(),
                 cc.getEconomicValue(),
-                cc.getPriorityScore()
+                cc.getPriorityScore(),
+                recommendedAction
         );
     }
 }

--- a/backend/src/main/java/com/team42/churninsight/prediction/api/dto/PredictionResponse.java
+++ b/backend/src/main/java/com/team42/churninsight/prediction/api/dto/PredictionResponse.java
@@ -9,7 +9,6 @@ import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.Set;
 
 public record PredictionResponse(

--- a/backend/src/main/java/com/team42/churninsight/prediction/enums/Occupation.java
+++ b/backend/src/main/java/com/team42/churninsight/prediction/enums/Occupation.java
@@ -2,7 +2,7 @@ package com.team42.churninsight.prediction.enums;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public enum Occupation {
+public enum     Occupation {
     @JsonProperty("Retired") RETIRED,
     @JsonProperty("Unemployed") UNEMPLOYED,
     @JsonProperty("Student") STUDENT,

--- a/backend/src/main/java/com/team42/churninsight/prediction/repository/PredictionRepository.java
+++ b/backend/src/main/java/com/team42/churninsight/prediction/repository/PredictionRepository.java
@@ -1,7 +1,15 @@
 package com.team42.churninsight.prediction.repository;
 
+import com.team42.churninsight.customer.entity.Customer;
 import com.team42.churninsight.prediction.Prediction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PredictionRepository extends JpaRepository<Prediction, Long> {
+
+    @Query(value = "SELECT p.recommended_action FROM predictions p WHERE p.customer_id = :customerId ORDER BY p.prediction_date DESC LIMIT 1", nativeQuery = true)
+    Optional<String> findLastRecommendedActionByCustomer(@Param("customerId") Long customerId);
 }


### PR DESCRIPTION
Se agrega el campo `recommended_action` al DTO `CriticalCustomerResponse`.

La acción recomendada se obtiene a partir de la **última predicción** asociada a cada cliente crítico y se incluye en la respuesta del endpoint.

Además, se limita la consulta de clientes críticos al **top 5 ordenado por priority_score**, evitando retornar toda la lista de clientes.

## Cambios principales
- Se añade `recommended_action` al response de clientes críticos
- Se consulta la última predicción por cliente
- Se optimiza la búsqueda limitando a 5 resultados